### PR TITLE
✨ Enable accessing and plotting weights

### DIFF
--- a/modlyn/eval/__init__.py
+++ b/modlyn/eval/__init__.py
@@ -3,7 +3,9 @@
 .. autosummary::
    :toctree: .
 
-   CompareScoresJaccard
+   CompareScores
 
 """
-from ._jaccard import CompareScoresJaccard
+from ._jaccard import CompareScores
+
+CompareScoresJaccard = CompareScores  # backward compat

--- a/modlyn/eval/_jaccard.py
+++ b/modlyn/eval/_jaccard.py
@@ -6,7 +6,7 @@ import pandas as pd
 import seaborn as sns
 
 
-class CompareScoresJaccard:
+class CompareScores:
     """Class for comparing feature importance methods using Jaccard index."""
 
     def __init__(self, dataframes, n_top_values=None):
@@ -134,9 +134,9 @@ class CompareScoresJaccard:
                     )
 
         # Formatting
-        ax.set_xlabel("Number of selected top features (n_top)")
-        ax.set_ylabel("Jaccard index")
-        ax.set_title("Jaccard index measuring overlap of selected features")
+        ax.set_xlabel("Number of Top Features (n_top)")
+        ax.set_ylabel("Jaccard Index")
+        ax.set_title("Jaccard Index vs Top-N Features")
         ax.set_xticks(x + width * (n_pairs - 1) / 2)
         ax.set_xticklabels(n_top_values)
         ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left")
@@ -144,5 +144,30 @@ class CompareScoresJaccard:
         ax.set_ylim(0, None)
 
         plt.tight_layout()
-        plt.close()  # Close the figure to prevent automatic display
+
+    def plot_heatmaps(self):
+        """Plot heatmaps for all methods side by side."""
+        # Sort columns and index alphabetically for each dataframe
+        dfs_sorted = [df.sort_index().sort_index(axis=1) for df in self.dataframes]
+        method_names = [df.attrs["method_name"] for df in self.dataframes]
+
+        # Find global min and max across all dataframes
+        vmin = min(df.min().min() for df in dfs_sorted)
+        vmax = max(df.max().max() for df in dfs_sorted)
+
+        # Create subplots
+        n_methods = len(dfs_sorted)
+        fig, axes = plt.subplots(1, n_methods, figsize=(5 * n_methods, 6))
+
+        # Handle single method case
+        if n_methods == 1:
+            axes = [axes]
+
+        # Plot heatmaps
+        for i, (df, method_name) in enumerate(zip(dfs_sorted, method_names)):
+            sns.heatmap(df, ax=axes[i], cmap="viridis", vmin=vmin, vmax=vmax, cbar=True)
+            axes[i].set_title(method_name)
+
+        plt.tight_layout()
+        plt.close()
         return fig


### PR DESCRIPTION
New features.

Ref: https://lamin.ai/laminlabs/arrayloader-benchmarks/transform/BhlpqNRWn3G00007

## Accessing weights via `.get_weights()`

Example.

```python
logreg = mn.models.SimpleLogReg(
    adata=adata,
    label_column="cell_line",    
    learning_rate=1e-1,
    weight_decay=1e-3,
)
logreg.fit(
    adata_train=adata,
    adata_val=adata[:20],
    train_dataloader_kwargs={
        "batch_size": 128,
        "drop_last": True,
        "num_workers": 4
    },
    max_epochs=5,
)
df_modlyn_logreg = logreg.get_weights()
df_modlyn_logreg.head()
```

## Plotting heatmaps via `plot_heatmaps()`

Example.

```
compare = mn.eval.CompareScoresJaccard([df_modlyn_logreg, df_scanpy_logreg, df_scanpy_wilcoxon], n_top_values=[5, 10, 25])
compare.plot_heatmaps()
```

<img width="1402" height="552" alt="image" src="https://github.com/user-attachments/assets/f2d04d5e-e651-4f79-97d6-eff440a5f846" />
